### PR TITLE
Rename CI workflows for development and main branches

### DIFF
--- a/.github/workflows/on-commit-dev.yml
+++ b/.github/workflows/on-commit-dev.yml
@@ -1,5 +1,5 @@
 # run on commit
-name: CI
+name: CI-dev
 permissions:
   contents: write
 

--- a/.github/workflows/on-commit-main.yml
+++ b/.github/workflows/on-commit-main.yml
@@ -1,5 +1,5 @@
 # run on commit
-name: CI
+name: CI-main
 permissions:
   contents: write
 

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -2,6 +2,10 @@
 name: Create and publish a Docker images to GitHub Packages
 
 on:
+  workflow_run:
+    workflows: ["CI-main"]
+    types:
+      - completed
   release:
     types: [created, published]
   push:


### PR DESCRIPTION
This PR renames the CI workflows for the development and main branches to `CI-dev` and `CI-main`, respectively. Additionally, it updates the `on-release.yml` file to trigger the release workflow upon the completion of the `CI-main` workflow, enhancing the CI/CD process.