### PR TITLE
Fix workflow conditions for image builds

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -16,8 +16,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-#   IS_RELEASE: ${{ github.event_name == 'release' }}
-  IS_RELEASE: Trues
+  IS_RELEASE: ${{ github.event_name == 'release' }}
+  # IS_RELEASE: True
   DJANGO_SUFFIX: -django
   FRONTEND_SUFFIX: -frontend
   NGINX_SUFFIX: -nginx
@@ -26,7 +26,6 @@ env:
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image-django:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
@@ -86,7 +85,6 @@ jobs:
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ env.DJANGO_SUFFIX }}:$STRIPPED_TAG
 
   build-and-push-image-frontend:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     permissions:
@@ -143,7 +141,6 @@ jobs:
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ env.FRONTEND_SUFFIX }}:$STRIPPED_TAG
 
   build-and-push-image-nginx:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     permissions:
@@ -200,7 +197,6 @@ jobs:
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ env.NGINX_SUFFIX }}:$STRIPPED_TAG
 
   build-and-push-image-psql:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
This pull request restores the event checks for image build workflows, ensuring that the `IS_RELEASE` environment variable is correctly set based on the event type. The previous configuration mistakenly set `IS_RELEASE` to `True` unconditionally, which could lead to unintended behavior during builds. The changes ensure that the workflows are triggered appropriately based on the event context.