### PR TITLE
Update release workflow to always set IS_RELEASE to True

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -16,8 +16,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  IS_RELEASE: ${{ github.event_name == 'release' }}
-  # IS_RELEASE: True
+  # IS_RELEASE: ${{ github.event_name == 'release' }}
+  IS_RELEASE: True
   DJANGO_SUFFIX: -django
   FRONTEND_SUFFIX: -frontend
   NGINX_SUFFIX: -nginx


### PR DESCRIPTION
This pull request modifies the release workflow to ensure that the `IS_RELEASE` environment variable is always set to `True`, regardless of the event type. This change simplifies the workflow and ensures consistent behavior during releases. Additionally, it includes merges from the development branch to keep the CI fixes up to date.